### PR TITLE
Gear 7557 fix mr processing error

### DIFF
--- a/fw_presidio_image_redactor/fw_scan_and_redact.py
+++ b/fw_presidio_image_redactor/fw_scan_and_redact.py
@@ -402,9 +402,6 @@ class FwScanRedactEngine(DicomImageRedactorEngine):
                 bbox_coords_dict[str(image_path.stem)] = bbox_coords  # bbox_coords
                 annotation_coords[instance_metadata["imagePath"]] = bbox_coords
 
-                # Apply common bboxes
-                self.apply_common_bboxes(annotation_coords)
-
             input_file_count += 1
             if input_file_count in file_markers:
                 file_progress_percent = file_markers.get(input_file_count)
@@ -418,6 +415,11 @@ class FwScanRedactEngine(DicomImageRedactorEngine):
                 with open(debug_analyzer_results, "w") as fp:
                     yaml.dump(analyzer_results, fp, sort_keys=False)
 
+        # Apply common bboxes
+        #TODO: add detailed description of why this is accurate for 
+        #      non-multi-frame volume. 
+        self.apply_common_bboxes(annotation_coords)
+        
         phi_found = any(
             len(phi_check) >= 1 for phi_check in list(analyzer_dict.values())
         )

--- a/manifest.json
+++ b/manifest.json
@@ -83,7 +83,7 @@
     },
     "gear-builder": {
       "category": "converter",
-      "image": "flywheel/nacc-presidio-image-redactor:0.1.4"
+      "image": "flywheel/nacc-presidio-image-redactor:0.1.5-rc1"
     }
   },
   "description": "This gear utilizes Mircrosoft's open source Presidio SDK to scan images for potential Personal Identifiable Information (PII), report on PII findings, and redact PII contained within pixel data.",
@@ -143,5 +143,5 @@
   "name": "nacc-presidio-image-redactor",
   "source": "https://microsoft.github.io/presidio/",
   "url": "https://gitlab.com/flywheel-io/scientific-solutions/gears/presidio-image-redactor",
-  "version": "0.1.4"
+  "version": "0.1.5-rc1"
 }


### PR DESCRIPTION
Recent change for 0.1.4 causes failure on MR images. 
version 0.1.3 passed on the same MR images before. 
0.1.3 also passed on 16887 cases. 
https://naccdata.flywheel.io/#/jobs/67c74784c2bf66c939cc020c?sort=created:desc&state=complete&gear=presidio-image-redactor

Thus reverting the small change in 0.1.4 